### PR TITLE
manifest: allow user to set keyboard shortcut

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,11 @@
         "scripts": ["background.js"],
         "persistent": false
     },
+    
+    "commands": {
+        "_execute_browser_action": {
+        }
+    },
 
     "permissions": [
         "activeTab"


### PR DESCRIPTION
This allows users to set a keyboard shortcut for the browser action.

Docs:

* https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#special_shortcuts
* https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#updating_shortcuts
* Example: https://github.com/gorhill/uBlock/blob/2e6cc8a36a35c1893cf2151340216c4920995028/platform/firefox/manifest.json#L22